### PR TITLE
Fixed rotate to rotation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,12 +313,12 @@ Size:
 <FontAwesomeIcon icon="spinner" size="6x" />
 ```
 
-Rotate:
+Rotation:
 
 ```javascript
-<FontAwesomeIcon icon="spinner" rotate={90} />
-<FontAwesomeIcon icon="spinner" rotate={180} />
-<FontAwesomeIcon icon="spinner" rotate={270} />
+<FontAwesomeIcon icon="spinner" rotation={90} />
+<FontAwesomeIcon icon="spinner" rotation={180} />
+<FontAwesomeIcon icon="spinner" rotation={270} />
 ```
 
 Pull left or right:
@@ -340,7 +340,8 @@ Power Transforms:
 
 ```javascript
 <FontAwesomeIcon icon="spinner" transform="shrink-6 left-4" />
-<FontAwesomeIcon icon="spinner" transform={{ rotate: 42 }} />
+<FontAwesomeIcon icon="spinner" transform={{ 
+: 42 }} />
 ```
 
 Composition:


### PR DESCRIPTION
Created #80 a while back as `{ rotate: 90 }` wasn't working. It was then pointed out that it's not `rotate`, but `rotation`. This works, so I'm changing the documentation to reflect the correct key.